### PR TITLE
Add option do supply a mirror to replace 'http://dl.nwjs.io'

### DIFF
--- a/bin/nwd.js
+++ b/bin/nwd.js
@@ -21,7 +21,7 @@ commander.command('stable').action(NWD.commands.stable);
 
 commander.command('caches').action(NWD.commands.caches);
 
-commander.command('download').option('-v,--version <version>').option('-p,--platform <platform>').option('-a,--arch <arch>').option('-f,--flavor <flavor>').action(NWD.commands.download);
+commander.command('download').option('-v,--version <version>').option('-p,--platform <platform>').option('-a,--arch <arch>').option('-f,--flavor <flavor>').option('-m,--mirror <mirror_url>').action(NWD.commands.download);
 
 if (process.argv.length <= 2) {
     commander.help();

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -110,13 +110,12 @@ var caches = function caches() {
 
 var download = function download(command) {
 
-    var progressbar = null;
-
     NWD.DownloadBinary({
         version: typeof command.version == 'string' ? command.version : null,
         platform: command.platform,
         arch: command.arch,
         flavor: command.flavor,
+        mirror: command.mirror,
         showProgressbar: true
     }, function (err, fromCache, path) {
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@
 
 var _slicedToArray = function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"]) _i["return"](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError("Invalid attempt to destructure non-iterable instance"); } }; }();
 
-require('babel-polyfill');
+if (!global._babelPolyfill) require('babel-polyfill');
 
 var _require = require('path');
 
@@ -244,6 +244,8 @@ var DownloadBinary = function DownloadBinary(_ref, callback) {
     var arch = _ref$arch === undefined ? null : _ref$arch;
     var _ref$flavor = _ref.flavor;
     var flavor = _ref$flavor === undefined ? null : _ref$flavor;
+    var _ref$mirror = _ref.mirror;
+    var mirror = _ref$mirror === undefined ? 'http://dl.nwjs.io' : _ref$mirror;
     var _ref$showProgressbar = _ref.showProgressbar;
     var showProgressbar = _ref$showProgressbar === undefined ? false : _ref$showProgressbar;
     var _ref$progressCallback = _ref.progressCallback;
@@ -299,7 +301,7 @@ var DownloadBinary = function DownloadBinary(_ref, callback) {
 
                         flavor = flavor ? flavor : 'normal';
 
-                        url = 'http://dl.nwjs.io/' + version + '/nwjs' + (flavor == 'normal' ? '' : '-' + flavor) + '-' + version + '-' + target + EXTENSIONS[target];
+                        url = mirror + '/' + version + '/nwjs' + (flavor == 'normal' ? '' : '-' + flavor) + '-' + version + '-' + target + EXTENSIONS[target];
 
 
                         debug('url:', url);

--- a/src/bin/nwd.js
+++ b/src/bin/nwd.js
@@ -28,6 +28,7 @@ commander.command('download')
 .option('-p,--platform <platform>')
 .option('-a,--arch <arch>')
 .option('-f,--flavor <flavor>')
+.option('-m,--mirror <mirror_url>')
 .action(NWD.commands.download);
 
 if(process.argv.length <= 2) {

--- a/src/lib/commands.js
+++ b/src/lib/commands.js
@@ -78,13 +78,12 @@ const caches = () => {
 
 const download = (command) => {
 
-    var progressbar = null;
-
     NWD.DownloadBinary({
         version: typeof command.version == 'string' ? command.version : null,
         platform: command.platform,
         arch: command.arch,
         flavor: command.flavor,
+        mirror: command.mirror,
         showProgressbar: true
     }, (err, fromCache, path) => {
 

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -175,6 +175,7 @@ const DownloadBinary = ({
     platform = null,
     arch = null,
     flavor = null,
+    mirror = 'http://dl.nwjs.io',
     showProgressbar = false,
     progressCallback = null
 }, callback) => {
@@ -204,7 +205,7 @@ const DownloadBinary = ({
 
         flavor = flavor ? flavor : 'normal';
 
-        const url = `http://dl.nwjs.io/${ version }/nwjs${ flavor == 'normal' ? '' : '-' + flavor}-${ version }-${ target }${ EXTENSIONS[target] }`;
+        const url = `${ mirror }/${ version }/nwjs${ flavor == 'normal' ? '' : '-' + flavor}-${ version }-${ target }${ EXTENSIONS[target] }`;
 
         debug('url:', url);
 


### PR DESCRIPTION
Add a switch to set a mirror url. Maybe in the future this could also be configured trough an env variable and .npmrc?
